### PR TITLE
Remove flex on app, add padding to page not found message

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -3,12 +3,10 @@
   background-position: center;
   background-attachment: fixed;
   min-height: 100vh;
-  display: flex;
 }
 
 .not-found-msg {
   width: 100%;
-  justify-self: center;
-  align-self: center;
+  padding-top: 25vh;
   text-align: center;
 }


### PR DESCRIPTION
 ## Description
Fixed a bug that was causing the Home Page to flex to the left once the window was extended far enough.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

#### Please add appreciative feedback in the comment section of this PR after reveiwing.
